### PR TITLE
[docs][dex] add basic redirect for UI/other external references

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -570,10 +570,10 @@ navbar-links:
     url: https://app.paradex.trade
 
 redirects:
-  - source: "{/:folder}/:slug"
-    destination: "/documentation{/:folder}/:slug"
-  - source: "/developer-portal{/:folder}/:slug"
-    destination: "/api-reference{/:folder}/:slug"
+  - source: "/:folder/:slug"
+    destination: "/documentation/:folder/:slug"
+  - source: "/developer-portal/:folder/:slug"
+    destination: "/api-reference/:folder/:slug"
 
 layout: 
   header-height: 72px


### PR DESCRIPTION
Discovered after publishing new docs, that the UI still references these.
Thankfully Fern has a redirect feature we can use!

Added two redirects to catch a good amount of these.