### PR TITLE
update documentation regarding minimum owner share

### DIFF
--- a/fern/apis/prod_rest/openapi/openapi.json
+++ b/fern/apis/prod_rest/openapi/openapi.json
@@ -5346,6 +5346,11 @@
                     "type": "string",
                     "example": "1"
                 },
+                "min_owner_share_percentage": {
+                    "description": "Minimum share percentage (0-100) the vault owner must maintain on the vault",
+                    "type": "string",
+                    "example": "5"
+                },
                 "vault_factory_address": {
                     "description": "Address of the vault factory contract",
                     "type": "string",

--- a/fern/apis/prod_rest/openapi/openapi.json
+++ b/fern/apis/prod_rest/openapi/openapi.json
@@ -5346,11 +5346,6 @@
                     "type": "string",
                     "example": "1"
                 },
-                "min_owner_share_percentage": {
-                    "description": "Minimum share percentage (0-100) the vault owner must maintain on the vault",
-                    "type": "string",
-                    "example": "5"
-                },
                 "vault_factory_address": {
                     "description": "Address of the vault factory contract",
                     "type": "string",

--- a/fern/apis/testnet_rest/openapi/openapi.json
+++ b/fern/apis/testnet_rest/openapi/openapi.json
@@ -5451,6 +5451,11 @@
           "type": "string",
           "example": "1"
         },
+        "min_owner_share_percentage": {
+                    "description": "Minimum share percentage (0-100) the vault owner must maintain on the vault",
+                    "type": "string",
+                    "example": "5"
+                },
         "vault_factory_address": {
           "description": "Address of the vault factory contract",
           "type": "string",

--- a/fern/apis/testnet_rest/openapi/openapi.json
+++ b/fern/apis/testnet_rest/openapi/openapi.json
@@ -5455,7 +5455,7 @@
           "description": "Minimum share percentage (0-100) the vault owner must maintain on the vault",
           "type": "string",
           "example": "5"
-                },
+        },
         "vault_factory_address": {
           "description": "Address of the vault factory contract",
           "type": "string",

--- a/fern/apis/testnet_rest/openapi/openapi.json
+++ b/fern/apis/testnet_rest/openapi/openapi.json
@@ -5451,11 +5451,6 @@
           "type": "string",
           "example": "1"
         },
-        "min_owner_share_percentage": {
-          "description": "Minimum share percentage (0-100) the vault owner must maintain on the vault",
-          "type": "string",
-          "example": "5"
-        },
         "vault_factory_address": {
           "description": "Address of the vault factory contract",
           "type": "string",

--- a/fern/apis/testnet_rest/openapi/openapi.json
+++ b/fern/apis/testnet_rest/openapi/openapi.json
@@ -5452,9 +5452,9 @@
           "example": "1"
         },
         "min_owner_share_percentage": {
-                    "description": "Minimum share percentage (0-100) the vault owner must maintain on the vault",
-                    "type": "string",
-                    "example": "5"
+          "description": "Minimum share percentage (0-100) the vault owner must maintain on the vault",
+          "type": "string",
+          "example": "5"
                 },
         "vault_factory_address": {
           "description": "Address of the vault factory contract",

--- a/fern/pages/vaults/faqs.mdx
+++ b/fern/pages/vaults/faqs.mdx
@@ -19,12 +19,6 @@ title: FAQs
   depositors proportional to their share in the vault.
 </Accordion>
 
-<Accordion title="What is the minimum owner share?">
-  The minimum owner share is the percentage of the vault that must be maintained
-  by the vault owner. This ensures the owner has "skin in the game" and aligns
-  their interests with other depositors.
-</Accordion>
-
 <Accordion title="How long after my deposit can I withdraw my funds?">
   Because withdrawal transactions cannot be performed in the same block as a
   deposit, there is currently around a **5 minute** window where you will not be

--- a/fern/pages/vaults/key-features.mdx
+++ b/fern/pages/vaults/key-features.mdx
@@ -15,9 +15,6 @@ _Configurable by the vault owner :_
 * Profit Share (between 0% and 20%)
 * Lockup Period (between 1 and 4 days)
 
-_Global Parameters :_
-
-* Minimum Owner Share (5%) : The owner is restricted from withdrawal if that reduces their share below 5%. This increases the performance incentive for the owner
 
 ## Vault Tokens
 


### PR DESCRIPTION
Hi Team,

According to the discussions on Discord, the minimum owner share percentage setting for a Vault should have been removed from the app by now.
As a suggestion, I reviewed the documentation and identified all instances where it was mentioned, removing them accordingly.

I hope this helps pinpoint where the changes need to be made.

Best regards,
Thomas Price