### PR TITLE
Adding FartCoin and IO specs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -315,6 +315,9 @@ navigation:
             - page: EIGEN-USD-PERP
               slug: eigen-usd-perp
               path: ./pages/instruments-guide/futures/tier-2/eigen-usd-perp.mdx
+            - page: FARTCOIN-USD-PERP
+              slug: fartcoin-usd-perp
+              path: ./pages/instruments-guide/futures/tier-2/fartcoin-usd-perp.mdx
             - page: FIL-USD-PERP
               slug: fil-usd-perp
               path: ./pages/instruments-guide/futures/tier-2/fil-usd-perp.mdx
@@ -336,6 +339,9 @@ navigation:
             - page: INJ-USD-PERP
               slug: inj-usd-perp
               path: ./pages/instruments-guide/futures/tier-2/inj-usd-perp.mdx
+            - page: IO-USD-PERP
+              slug: io-usd-perp
+              path: ./pages/instruments-guide/futures/tier-2/io-usd-perp.mdx
             - page: JTO-USD-PERP
               slug: jto-usd-perp
               path: ./pages/instruments-guide/futures/tier-2/jto-usd-perp.mdx

--- a/fern/pages/instruments-guide/futures/tier-2/fartcoin-usd-perp.mdx
+++ b/fern/pages/instruments-guide/futures/tier-2/fartcoin-usd-perp.mdx
@@ -1,0 +1,20 @@
+---
+---
+export const contractName = "FARTCOIN-USD-PERP";
+export const productType = "Linear Perpetual Future";
+export const settlementCurrency = "USDC";
+export const baseCurrency = "FARTCOIN";
+export const quoteCurrency = "USD";
+export const tickSize = "0.0001 USD";
+export const orderSizeIncrement = "1 FARTCOIN";
+export const minOrderValue = "50 USD";
+export const maxOrderSize = "390,000 FARTCOIN";
+export const maxOpenOrders = "50";
+export const positionLimit = "1,300,000 FARTCOIN";
+export const priceBandFactor = "5%";
+export const fundingClampingRate = "5%";
+export const ewmaFactor = "15%";
+export const imf = "20%";
+export const mmf = "50%";
+
+<Markdown src="../../../../snippets/contractTemplate.mdx"/>

--- a/fern/pages/instruments-guide/futures/tier-2/io-usd-perp.mdx
+++ b/fern/pages/instruments-guide/futures/tier-2/io-usd-perp.mdx
@@ -1,0 +1,20 @@
+---
+---
+export const contractName = "IO-USD-PERP";
+export const productType = "Linear Perpetual Future";
+export const settlementCurrency = "USDC";
+export const baseCurrency = "IO";
+export const quoteCurrency = "USD";
+export const tickSize = "0.0001 USD";
+export const orderSizeIncrement = "1 IO";
+export const minOrderValue = "50 USD";
+export const maxOrderSize = "100,000 IO";
+export const maxOpenOrders = "50";
+export const positionLimit = "340,000 IO";
+export const priceBandFactor = "5%";
+export const fundingClampingRate = "5%";
+export const ewmaFactor = "15%";
+export const imf = "20%";
+export const mmf = "50%";
+
+<Markdown src="../../../../snippets/contractTemplate.mdx"/>


### PR DESCRIPTION
Description: Adding FartCoin and IO instrument guides in the documentation
Testing: Locally tested with fern docs dev
Ticket: skip