### PR TITLE
[dex][docs] Adding Usual Contract Specs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -444,6 +444,9 @@ navigation:
             - page: TURBO-USD-PERP
               slug: turbo-usd-perp
               path: ./pages/instruments-guide/futures/tier-2/turbo-usd-perp.mdx
+            - page: USUAL-USD-PERP
+              slug: usual-usd-perp
+              path: ./pages/instruments-guide/futures/tier-2/usual-usd-perp.mdx
             - page: WIF-USD-PERP
               slug: wif-usd-perp
               path: ./pages/instruments-guide/futures/tier-2/wif-usd-perp.mdx

--- a/fern/pages/instruments-guide/futures/tier-2/usual-usd-perp.mdx
+++ b/fern/pages/instruments-guide/futures/tier-2/usual-usd-perp.mdx
@@ -1,0 +1,20 @@
+---
+---
+export const contractName = "USUAL-USD-PERP";
+export const productType = "Linear Perpetual Future";
+export const settlementCurrency = "USDC";
+export const baseCurrency = "USUAL";
+export const quoteCurrency = "USD";
+export const tickSize = "0.0001 USD";
+export const orderSizeIncrement = "1 USUAL";
+export const minOrderValue = "50 USD";
+export const maxOrderSize = "230,000 USUAL";
+export const maxOpenOrders = "50";
+export const positionLimit = "770,000 USUAL";
+export const priceBandFactor = "5%";
+export const fundingClampingRate = "5%";
+export const ewmaFactor = "15%";
+export const imf = "20%";
+export const mmf = "50%";
+
+<Markdown src="../../../../snippets/contractTemplate.mdx"/>


### PR DESCRIPTION
Description: Adding contract specs for usual-usd-perp based on the market spec sheet

Testing: Tested using fern docs dev command in local environment