### PR TITLE
fix grammar error

### DIFF
--- a/fern/pages/trading/trading-fees.mdx
+++ b/fern/pages/trading/trading-fees.mdx
@@ -14,7 +14,7 @@ In due course, a tiered fee system may be introduced.
 
 When two participants execute a trade on Paradex the system applies two different fee rates on the participants, one rate on the Maker side and another rate of the Taker side.
 
-* A **Maker** order is an order that provides liquidity to the order book. It's an order that doesnt get filled immediately since it is not matched with an existing order. Instead, it remains on the order book until someone else matches it.
+* A **Maker** order is an order that provides liquidity to the order book. It's an order that doesn't get filled immediately since it is not matched with an existing order. Instead, it remains on the order book until someone else matches it.
 * A **Taker** order is an order that removes liquidity from the order book. It's an order that gets filled immediately because it matches with an existing order in the order book.
 
 **Let's illustrate this with an example:**


### PR DESCRIPTION
Fixed a grammatical error in the documentation. Replaced ‘doesnt’ with ‘doesn’t’ for correct usage