### PR TITLE
docs: fix minor typos

### DIFF
--- a/fern/pages/accounts/deposits-and-withdrawals/ethereum-wallets.mdx
+++ b/fern/pages/accounts/deposits-and-withdrawals/ethereum-wallets.mdx
@@ -26,7 +26,7 @@ Note: This action will require 1-2 L1 signatures. If this is your first deposit 
 
 ## Withdrawals
 
-Initiate a withdrawal from your Paradex account to the Starknet bridge and it will automatially be sent to your L1 once it is available.
+Initiate a withdrawal from your Paradex account to the Starknet bridge and it will automatically be sent to your L1 once it is available.
 
 <img src="../../../assets/Paradex-withdraw-Flow.png" alt=""/>
 

--- a/fern/pages/accounts/overview.mdx
+++ b/fern/pages/accounts/overview.mdx
@@ -17,7 +17,7 @@ Our app only displays available bridge paths between source and destination chai
 
 ## Starknet Wallets
 
-We have extended key generation to Starknet accounts, enabling your connected Starknet wallet to [deterministically derive a Paradex Account](../getting-started/architecture-overview/wallet-integration). Deposits and withdraws on Starknet Wallets would be done via our [Cross Chain Bridging](deposits-and-withdrawals/cross-chain-bridging).
+We have extended key generation to Starknet accounts, enabling your connected Starknet wallet to [deterministically derive a Paradex Account](../getting-started/architecture-overview/wallet-integration). Deposits and withdrawals on Starknet Wallets would be done via our [Cross Chain Bridging](deposits-and-withdrawals/cross-chain-bridging).
 
 ## Email and Social Wallets
 


### PR DESCRIPTION
Checked all the ‘md’ and 'mdx' files in the repository, found some typos that needed to be fixed because they clearly changed the meaning, and fix them.

There were also some awkward wording and punctuation, but I didn't fix those because they don't detract too much from the meaning of the original documentation and don't cause any problems in understanding the documentation.

In the commit, briefly mentioned the typo corrections.

Hope this helps and wish success with your project.