### PR TITLE
[docs][dex] update link in vaults faq

### DIFF
--- a/fern/pages/vaults/faqs.mdx
+++ b/fern/pages/vaults/faqs.mdx
@@ -25,7 +25,7 @@ title: FAQs
   able to withdraw fund immediately after deposit. This is the time that is
   required to created this new block for the withdrawal transaction. Otherwise,
   the time is also limited by the [Lockup
-  Period](https://docs.paradex.trade/vaults/tutorials/withdrawal#note-you-will-not-be-able-to-withdraw-from-the-vault-if-your-minimum-lockup-period-of-not-over-yet)
+  Period](https://docs.paradex.trade/documentation/vaults/tutorials/vault-withdrawal#note-you-will-not-be-able-to-withdraw-from-the-vault-if-your-minimum-lockup-period-of-not-over-yet)
   that is configured for the Vault. This can be found just above the Deposit
   button with the other Vault status.
 </Accordion>


### PR DESCRIPTION
Got a warning from Fern's cli on a broken link:

[docs]:         pages/vaults/faqs.mdx
                broken link to /vaults/tutorials/withdrawal
                	fix here: pages/vaults/faqs.mdx:27:35
                
[docs]:         Found 1 errors and 1 warnings in 3.721 seconds. Run fern check --warnings to print out the warnings not shown.


Updating this