### PR TITLE
[hotfix] pull api playground

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -26,3 +26,7 @@
 .hide-svg .fern-mdx-link svg {
   display: none;
 }
+
+a[id*="playground-button"] {
+  display: none;
+ }


### PR DESCRIPTION
There was a change on Fern's side that prevents us from disabling the API playground.
This isn't super usable yet without the auth element.

They have provided a way to disable the button via Custom CSS.