### PR TITLE
Upgrade fern version

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -869,3 +869,6 @@ colors:
 css: ./assets/styles.css
 js:
   - path: ./dist/dd-rum.js
+
+experimental:
+  openapi-parser-v3: true

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "paradex",
-  "version": "0.60.4"
+  "version": "0.60.5"
 }


### PR DESCRIPTION
This PR upgrades the Fern CLI to remove the duplicate enum values bug on the websocket references.