### PR TITLE
chore: bump cli version

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "paradex",
-  "version": "0.62.1"
+  "version": "0.62.6"
 }


### PR DESCRIPTION
This PR restores response examples to endpoints marked with `x-fern-examples`.