### PR TITLE
Add clarification on margin transfer for isolated accounts

### DIFF
--- a/fern/pages/risk-system/paradex-risk-system.mdx
+++ b/fern/pages/risk-system/paradex-risk-system.mdx
@@ -7,6 +7,14 @@ Paradex currently only supports **Cross Margin (XM)** mode.
 
 There will be no “isolated margin” mode. In order to open an isolated position, the user can create a new separate account to trade a single instrument.
 
+> **Important**
+>
+> When opening a position from an isolated account (i.e. a sub-account), Paradex automatically transfers the required margin from the main account to a sub account. This may look like a withdrawal, but funds stay within your account.
+>
+> Once the position is closed, remaining funds are returned to the main account.
+>
+> Note: If the user is submitting the trade via API, **they must manually transfer the required margin to the isolated account before placing the order.**
+
 #### Instrument types
 
 All instruments are quoted and valued in USD.

--- a/fern/pages/trading/mobile-access-guide.mdx
+++ b/fern/pages/trading/mobile-access-guide.mdx
@@ -5,6 +5,8 @@ subtitle: Paradex offers two ways to access the platform on your mobile device.
 
 <Info>
 If you are not using email or social logins for your Paradex account, you will need your wallet mobile app installed on your device to login.
+
+For wallet connection, note that Rabby is a desktop browser extension and does not support mobile deep linking or in-app integration. To log in on mobile, we recommend using wallets like MetaMask, Coinbase, or other WalletConnect-compatible apps.
 </Info>
 
 


### PR DESCRIPTION
The original documentation was already in place, but it lacked clarity around how funds are transferred when opening an isolated position.

This update adds a short note explaining that funds are automatically moved to the sub-account once the position is opened.

We've received several support tickets related to this confusion, so this could help prevent further misunderstandings.