### PR TITLE
Add Rabby wallet compatibility note

### DIFF
--- a/fern/pages/trading/mobile-access-guide.mdx
+++ b/fern/pages/trading/mobile-access-guide.mdx
@@ -5,6 +5,8 @@ subtitle: Paradex offers two ways to access the platform on your mobile device.
 
 <Info>
 If you are not using email or social logins for your Paradex account, you will need your wallet mobile app installed on your device to login.
+
+For wallet connection, note that Rabby is a desktop browser extension and does not support mobile deep linking or in-app integration. To log in on mobile, we recommend using wallets like MetaMask, Coinbase, or other WalletConnect-compatible apps.
 </Info>
 
 

--- a/fern/pages/trading/mobile-access-guide.mdx
+++ b/fern/pages/trading/mobile-access-guide.mdx
@@ -6,7 +6,7 @@ subtitle: Paradex offers two ways to access the platform on your mobile device.
 <Info>
 If you are not using email or social logins for your Paradex account, you will need your wallet mobile app installed on your device to login.
 
-For wallet connection, note that Rabby is a desktop browser extension and does not support mobile deep linking or in-app integration. To log in on mobile, we recommend using wallets like MetaMask, Coinbase, or other WalletConnect-compatible apps.
+If your wallet does not offer mobile apps (eg. Rabby), you will not be able to use our Paradex mobile app. We are actively working on alternative login methods for this use case.
 </Info>
 
 


### PR DESCRIPTION
- Added a clarification in `mobile-access-guide.mdx` explaining that Rabby is a desktop-only wallet extension.
- Informs users that Rabby is a desktop browser extension and does not support mobile deep linking or in-app integration

This note was added in response to multiple support cases from users unable to connect Rabby via mobile browser or the Paradex app.
