### PR TITLE
Add <Steps> component to Vault tutorials: deposit, withdrawal, and close

### DIFF
--- a/fern/pages/vaults/tutorials/close-your-vault.mdx
+++ b/fern/pages/vaults/tutorials/close-your-vault.mdx
@@ -1,26 +1,33 @@
 ---
 title: Close your Vault
 ---
-**Step 1:** On the top right corner, click on the "Manage Vault" button.
 
-<img src="../../../assets/image (76).png" alt=""/>
+<Steps>
+  <Step title='Click "Manage Vault"'>
+    On the top right corner, click on the "Manage Vault" button.
 
-**Step 2:** Under "Manage Vault", click on "Close Vault". Type in your Vault Name to close your vault.
+    <img src="../../../assets/image (76).png" alt=""/>
+  </Step>
 
-<div>
+  <Step title='Click "Close Vault"'>
+    Under "Manage Vault", click on "Close Vault". Type in your Vault Name to close your vault.
 
-<img src="../../../assets/Screenshot 2024-10-23 122208.png" alt=""/>
+    <div>
+      <img src="../../../assets/Screenshot 2024-10-23 122208.png" alt=""/>
+      <img src="../../../assets/image (73).png" alt=""/>
+    </div>
+  </Step>
 
- 
+  <Step title='Withdraw from Vault'>
+    Once the Vault is closed, click on "Manage Vault" again and click "Withdraw" to withdraw from your vault.
 
-<img src="../../../assets/image (73).png" alt=""/>
+    <img src="../../../assets/image (74).png" alt=""/>
+  </Step>
 
-</div>
+  <Step title='Confirm Withdrawal'>
+    Enter the amount and click "Withdraw (USDC)". You will receive USDC in your main account.
 
-**Step 3:** Once the Vault is closed, the click on "Manage Vault" again and click "Withdraw" to withdraw from your vault.
+    <img src="../../../assets/image (75).png" alt=""/>
+  </Step>
+</Steps>
 
-<img src="../../../assets/image (74).png" alt=""/>
-
-**Step 4:** Enter the amount and click "Withdraw (USDC)". You will receive USDC in your main account.
-
-<img src="../../../assets/image (75).png" alt=""/>

--- a/fern/pages/vaults/tutorials/deposit.mdx
+++ b/fern/pages/vaults/tutorials/deposit.mdx
@@ -2,18 +2,28 @@
 title: Deposit
 ---
 
-#### Step 1: Select a Vault on the Vaults page that you wish to deposit in
+<Steps>
+  <Step title="Select a Vault">
+    Select a Vault on the Vaults page that you wish to deposit in.
 
-<img src="../../../assets/Screenshot 2024-10-08 at 3.41.31 PM.png" alt=""/>
+    <img src="../../../assets/Screenshot 2024-10-08 at 3.41.31 PM.png" alt=""/>
+  </Step>
 
-#### Step 2: On the Vaults Stats page, click on Deposit at the top right hand corner
+  <Step title="Click Deposit">
+    On the Vaults Stats page, click on Deposit at the top right hand corner.
 
-<img src="../../../assets/Screenshot 2024-10-08 at 3.42.50 PM.png" alt=""/>
+    <img src="../../../assets/Screenshot 2024-10-08 at 3.42.50 PM.png" alt=""/>
+  </Step>
 
-#### Step 3: Enter the Amount you wish to deposit in the Vault
+  <Step title="Enter Amount">
+    Enter the Amount you wish to deposit in the Vault.
 
-<img src="../../../assets/Screenshot 2024-10-08 at 3.43.45 PM.png" alt=""/>
+    <img src="../../../assets/Screenshot 2024-10-08 at 3.43.45 PM.png" alt=""/>
+  </Step>
 
-#### Step 4: Find your amount deposited at the "My Vault Deposit" section
+  <Step title="Check Your Deposit">
+    Find your amount deposited at the "My Vault Deposit" section.
 
-<img src="../../../assets/Screenshot 2024-09-23 at 2.42.39 PM.png" alt=""/>
+    <img src="../../../assets/Screenshot 2024-09-23 at 2.42.39 PM.png" alt=""/>
+  </Step>
+</Steps>

--- a/fern/pages/vaults/tutorials/withdrawal.mdx
+++ b/fern/pages/vaults/tutorials/withdrawal.mdx
@@ -2,19 +2,28 @@
 title: Withdrawal
 ---
 
-#### Step 1: Select a Vault on the Vaults page that you wish to withdraw from
+<Steps>
+  <Step title="Select a Vault">
+    Select a Vault on the Vaults page that you wish to withdraw from.
 
-<img src="../../../assets/Screenshot 2024-10-08 at 3.47.53 PM.png" alt=""/>
+    <img src="../../../assets/Screenshot 2024-10-08 at 3.47.53 PM.png" alt=""/>
+  </Step>
 
-#### Step 2: Click on the "Withdraw" button on the top right hand corner
+  <Step title='Click on "Withdraw"'>
+    Click on the "Withdraw" button on the top right hand corner.
 
-<img src="../../../assets/Screenshot 2024-10-08 at 3.47.12 PM.png" alt=""/>
+    <img src="../../../assets/Screenshot 2024-10-08 at 3.47.12 PM.png" alt=""/>
+  </Step>
 
-#### Step 3: Input the Amount and click "Withdraw (USDC)"
+  <Step title='Enter Amount and Confirm'>
+    Input the Amount and click "Withdraw (USDC)".
 
-<img src="../../../assets/Screenshot 2024-10-08 at 3.53.25 PM (1).png" alt=""/>
+    <img src="../../../assets/Screenshot 2024-10-08 at 3.53.25 PM (1).png" alt=""/>
+  </Step>
 
-#### Note: You will not be able to withdraw from the Vault if your minimum lockup period of not over yet
+  <Step title='Check Lockup Period'>
+    You will not be able to withdraw from the Vault if your minimum lockup period is not over yet.
 
-<img src="../../../assets/Screenshot 2024-10-08 at 3.49.42 PM.png" alt=""/>
-
+    <img src="../../../assets/Screenshot 2024-10-08 at 3.49.42 PM.png" alt=""/>
+  </Step>
+</Steps>


### PR DESCRIPTION
Added `<Steps>` component to the following Vault tutorial pages:

- Vault Deposit
- Vault Withdrawal
- Close your Vault

While the existing tutorials for Vaults were functional, they lacked structural consistency with other guides such as “Create a Vault,” which already use the <Steps> component.

By updating these pages to use <Steps>, we align them with Paradex’s documentation standards. 