### PR TITLE
fix: restore missing websocket examples in docs

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "paradex",
-  "version": "0.63.31"
+  "version": "0.63.36"
 }


### PR DESCRIPTION
## Changes: 
- upgrade CLI to `0.63.36`