### PR TITLE
Updating funding information for perp options (5d funding)

### DIFF
--- a/fern/pages/options/understanding-perpetual-options.mdx
+++ b/fern/pages/options/understanding-perpetual-options.mdx
@@ -80,7 +80,7 @@ For a BTC-USD-101000-C with:
 - Time Value: $500
 
 If Dave buys 5 contracts and holds for 1 hour with unchanged prices:
-- Funding PnL = -5 × ($500 × 5) = -$12,5000
+- Funding PnL = -5 × ($500 × 5) = -$12,500
 
 Funding accrues continuously as unrealized PnL and is realized whenever the position is updated.
 

--- a/fern/pages/options/understanding-perpetual-options.mdx
+++ b/fern/pages/options/understanding-perpetual-options.mdx
@@ -62,13 +62,13 @@ Time Value represents the premium or value traders are willing to pay for the op
 
 The funding mechanism is how Perpetual Options maintain their perpetual nature. Long positions continuously pay short positions a funding rate based on the option's time value.
 
-- **Funding Period:** 24 hours (funding is paid continuously)
+- **Funding Period:** 5 days (funding is paid continuously)
 - **Funding Premium:** The total amount of funding paid over the funding period, equal to the time value of the option:
   
   Funding Premium = Time Value = Mark Price - Intrinsic Value
 
 <Tip title="Core Idea" icon="leaf">
-The Funding Period is a critical concept to understand. It represents the expected period of time over which a user will pay the time value of the option via Funding. This is a parameter chosen by Paradex and is what makes the current Perpetual Option similar (but not equal to) a 24 hour dated option.
+The Funding Period is a critical concept to understand. It represents the expected period of time over which a user will pay the time value of the option via Funding. This is a parameter chosen by Paradex and is what makes the current Perpetual Option similar (but not equal to) a 5-day dated option.
 </Tip>
 
 ### Example
@@ -80,7 +80,7 @@ For a BTC-USD-101000-C with:
 - Time Value: $500
 
 If Dave buys 5 contracts and holds for 1 hour with unchanged prices:
-- Funding PnL = -5 × ($500 × 1/24) = -$104.17
+- Funding PnL = -5 × ($500 × 5) = -$12,5000
 
 Funding accrues continuously as unrealized PnL and is realized whenever the position is updated.
 


### PR DESCRIPTION
After we changed funding to 5d on perpetual options, documentation was still outdated showing old funding (24 hrs).
Updated text and example calculation