### PR TITLE
Updating funding details to 5d on Perp Options page

### DIFF
--- a/fern/pages/options/understanding-perpetual-options.mdx
+++ b/fern/pages/options/understanding-perpetual-options.mdx
@@ -73,7 +73,7 @@ The Funding Period is a critical concept to understand. It represents the expect
 
 ### Example
 
-For a BTC-USD-101000-C with:
+For a BTC-USD-104000-C with:
 - Spot Price: $100,000
 - Mark Price: $500
 - Intrinsic Value: $0 (out-of-the-money)

--- a/fern/pages/options/understanding-perpetual-options.mdx
+++ b/fern/pages/options/understanding-perpetual-options.mdx
@@ -79,8 +79,8 @@ For a BTC-USD-101000-C with:
 - Intrinsic Value: $0 (out-of-the-money)
 - Time Value: $500
 
-If Dave buys 5 contracts and holds for 5 days with unchanged prices:
-- Funding PnL = -5 × ($500 × 5) = -$12,500
+If Dave buys 5 contracts and holds for 8 hours with unchanged prices:
+- Funding PnL = -5 × ($500 / 5) * 8/24 = -$166.67
 
 Funding accrues continuously as unrealized PnL and is realized whenever the position is updated.
 

--- a/fern/pages/options/understanding-perpetual-options.mdx
+++ b/fern/pages/options/understanding-perpetual-options.mdx
@@ -62,13 +62,13 @@ Time Value represents the premium or value traders are willing to pay for the op
 
 The funding mechanism is how Perpetual Options maintain their perpetual nature. Long positions continuously pay short positions a funding rate based on the option's time value.
 
-- **Funding Period:** 24 hours (funding is paid continuously)
+- **Funding Period:** 5 days (funding is paid continuously)
 - **Funding Premium:** The total amount of funding paid over the funding period, equal to the time value of the option:
   
   Funding Premium = Time Value = Mark Price - Intrinsic Value
 
 <Tip title="Core Idea" icon="leaf">
-The Funding Period is a critical concept to understand. It represents the expected period of time over which a user will pay the time value of the option via Funding. This is a parameter chosen by Paradex and is what makes the current Perpetual Option similar (but not equal to) a 24 hour dated option.
+The Funding Period is a critical concept to understand. It represents the expected period of time over which a user will pay the time value of the option via Funding. This is a parameter chosen by Paradex and is what makes the current Perpetual Option similar (but not equal to) a 5-day dated option.
 </Tip>
 
 ### Example
@@ -79,8 +79,8 @@ For a BTC-USD-101000-C with:
 - Intrinsic Value: $0 (out-of-the-money)
 - Time Value: $500
 
-If Dave buys 5 contracts and holds for 1 hour with unchanged prices:
-- Funding PnL = -5 × ($500 × 1/24) = -$104.17
+If Dave buys 5 contracts and holds for 5 days with unchanged prices:
+- Funding PnL = -5 × ($500 × 5) = -$12,500
 
 Funding accrues continuously as unrealized PnL and is realized whenever the position is updated.
 


### PR DESCRIPTION
After we changed funding to 5d on Perp Options documentation was not reflecting that change. Updating to 5d.