### PR TITLE
[infra] Avoid opening empty PR with API sync

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -47,10 +47,6 @@ jobs:
         run: |
           npm install -g fern-api
 
-      - name: Run fern upgrade
-        if: ${{ steps.check-prs.outputs.PR_ALREADY_EXISTS == 'false' }}
-        run: fern upgrade
-
       - name: Check if there are changes to publish
         if: ${{ steps.check-prs.outputs.PR_ALREADY_EXISTS == 'false' }}
         id: check-diff
@@ -61,7 +57,9 @@ jobs:
           echo "changed=${changed}" >> $GITHUB_OUTPUT
 
       - name: Update OpenAPI Spec
-        if: ${{ steps.check-prs.outputs.PR_ALREADY_EXISTS == 'false' && github.event_name != 'pull_request' && steps.check-diff.outputs.changed == 'true' }}
+        # if: ${{ steps.check-prs.outputs.PR_ALREADY_EXISTS == 'false' && github.event_name != 'pull_request' && steps.check-diff.outputs.changed == 'true' }}
+        # DEBUGGING
+        if: ${{ steps.check-prs.outputs.PR_ALREADY_EXISTS == 'false' && steps.check-diff.outputs.changed == 'true' }}
         uses: fern-api/sync-openapi@v2
         with:
           token: ${{ secrets.OPENAPI_SYNC_TOKEN }}

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -57,9 +57,7 @@ jobs:
           echo "changed=${changed}" >> $GITHUB_OUTPUT
 
       - name: Update OpenAPI Spec
-        # if: ${{ steps.check-prs.outputs.PR_ALREADY_EXISTS == 'false' && github.event_name != 'pull_request' && steps.check-diff.outputs.changed == 'true' }}
-        # DEBUGGING
-        if: ${{ steps.check-prs.outputs.PR_ALREADY_EXISTS == 'false' && steps.check-diff.outputs.changed == 'true' }}
+        if: ${{ steps.check-prs.outputs.PR_ALREADY_EXISTS == 'false' && github.event_name != 'pull_request' && steps.check-diff.outputs.changed == 'true' }}
         uses: fern-api/sync-openapi@v2
         with:
           token: ${{ secrets.OPENAPI_SYNC_TOKEN }}

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "paradex",
-  "version": "0.64.12"
+  "version": "0.64.15"
 }


### PR DESCRIPTION
Fix is to avoid having a `fern upgrade` in the sync workflow.

The fern upgrade changes the fern config file 
and then thats being detected by the git diff 
in the Update OpenAPI Spec.

To upgrade do manually or separated:
in fact, also upgrade version manually from local.