### PR TITLE
Misspelling on main page next in rpi section

### DIFF
--- a/fern/pages/what-is-paradex.mdx
+++ b/fern/pages/what-is-paradex.mdx
@@ -18,7 +18,7 @@ all built on a blazingly fast blockchain.
 
 <CardGroup cols={3}>
   <Card title="Perpetual Futures" icon={<img src="../assets/perps-icon.svg" />} href="/trading/rpi">
-    Retail Price Improvement (RPI) ordres fill at prices inside the prevailing top-tier CEX spreads
+    Retail Price Improvement (RPI) orders fill at prices inside the prevailing top-tier CEX spreads
   </Card>
   <Card title="Perpetual Options" icon={<img src="../assets/options-icon.svg" />} href="/trading/perpetual-options/intro">
     Higher leverage than perpetual futures, no liquidation risk. Just pay higher funding


### PR DESCRIPTION
User pointed out misspelling in word "orders"