### PR TITLE
docs(vaults): add warning explanation to Unwind process when withdrawing from vault

### DIFF
--- a/fern/pages/vaults/tutorials/withdrawal.mdx
+++ b/fern/pages/vaults/tutorials/withdrawal.mdx
@@ -1,6 +1,11 @@
 ---
 title: Withdrawal
 ---
+<Warning>
+When withdrawing, your vault goes through an 'unwinding' period where funds remain exposed to the market until positions are fully closed and converted to USDC. 
+
+This process usually takes a few minutes depending on market conditions.
+</Warning>
 
 <Steps>
   <Step title="Select a Vault">


### PR DESCRIPTION
The Vault withdrawal tutorial lacked clarity about the “unwinding” phase, where funds remain exposed to market conditions until the underlying positions are fully closed.

This update adds a short note explaining what the unwinding process is and why it takes a few minutes.  

We’ve received several support tickets related to this confusion, so this should help reduce misunderstandings for users.
