### PR TITLE
Add warning about L1 wallet being permanently linked

### DIFF
--- a/fern/pages/introduction/architecture-overview/wallet-integration.mdx
+++ b/fern/pages/introduction/architecture-overview/wallet-integration.mdx
@@ -70,6 +70,12 @@ If “Remember Me” is checked when connecting the wallet, the Ethereum Signatu
 You should update the date and time on your device to be set automatically, to avoid issues when signing requests (e.g. during Onboarding/Authentication).\
 See [MacOS documentation](https://support.apple.com/en-gb/guide/mac-help/mchlp2996/mac) or [Windows documentation](https://support.microsoft.com/en-us/windows/how-to-set-your-time-and-time-zone-dfaa7122-479f-5b98-2a7b-fa0b6e01b261)
 
+<Warning>
+The L1 wallet you connect during onboarding is permanently linked to your Paradex L2 account and cannot be updated later. 
+
+If you want to operate with a different L1 wallet, you’ll need to create a new Paradex account.
+</Warning>
+
 ### References
 
 ***


### PR DESCRIPTION
We had received multiple Mava tickets from users asking if it’s possible to keep using the same L2 account but link it to a different L1 wallet.  

This PR adds a warning to the Wallet integration section to make it explicit that the L1 wallet connected during onboarding is permanently linked, and switching to another L1 requires creating a new Paradex account.  

The goal is to reduce confusion and prevent further support requests around this topic.
