### PR TITLE
clarify social login behavior and wallet linking

### DIFF
--- a/fern/pages/accounts/deposits-and-withdrawals/email-social-wallets.mdx
+++ b/fern/pages/accounts/deposits-and-withdrawals/email-social-wallets.mdx
@@ -2,6 +2,12 @@
 title: Email and Social Wallets
 ---
 
+<Warning>
+Each login method (Google, X, Discord, etc) generates a separate L2 on Paradex and the wallet linked to it cannot be changed. 
+
+If you try to log in directly with a different social account, Paradex will create a new wallet linked only to that method.
+</Warning>
+
 Email and Social wallets allow you to have an Ethereum account without having to manage the wallet yourself. 
 
 We understand that, as an email or social wallet user, you might want to transfer funds from/to centralized exchanges. You can do that via our [cross-chain bridge](./cross-chain-bridging) partner Layerswap. 

--- a/fern/pages/accounts/deposits-and-withdrawals/email-social-wallets.mdx
+++ b/fern/pages/accounts/deposits-and-withdrawals/email-social-wallets.mdx
@@ -3,9 +3,9 @@ title: Email and Social Wallets
 ---
 
 <Warning>
-Each login method (Google, X, Discord, etc) generates a separate L2 on Paradex and the wallet linked to it cannot be changed. 
+Each login method (Google, X, Discord, etc) generates a separate L2 on Paradex and the wallet linked to it cannot be changed.
 
-If you try to log in directly with a different social account, Paradex will create a new wallet linked only to that method.
+Adding other socials into Paradex after onboarding does not provide an alternative login to the same wallet. If you try to log in directly with a different social account, Paradex will create a new wallet linked only to that method. 
 </Warning>
 
 Email and Social wallets allow you to have an Ethereum account without having to manage the wallet yourself. 


### PR DESCRIPTION
- Clarifies that each social login (Google, X, Discord, etc.) creates a separate L2 account.
- The first login used becomes the primary account and its linked wallet cannot be changed.
- Linking other socials does not provide an alternative login to the same wallet.
- Based on recurring Mava tickets to reduce user confusion.