### PR TITLE
docs(xp): add warning that XP is permanently linked and non-transferable

### DIFF
--- a/fern/pages/points-and-referrals/xp.mdx
+++ b/fern/pages/points-and-referrals/xp.mdx
@@ -29,6 +29,11 @@ Linking your social media accounts (e.g., X and Discord) helps us better disting
 Users contributing to overall liquidity provision on the platform, particularly for low-volume pairs, may receive higher XP distribution.
 </Note>
 
+<Warning>
+XP points are permanently linked to the wallet that earned them. If you lose access to your initial onboarded wallet (e.g. private key exposure or losing access to your social login), the XP from that account cannot be migrated to a different wallet.
+</Warning>
+
+
 # XP Seasons
 
 ## Season 2 (LIVE!)


### PR DESCRIPTION
- Adds a warning clarifying that XP points are permanently tied to the wallet that earned them.
- Explains that if a user loses access to their onboarded wallet (e.g., private key exposure or loss of social login), XP cannot be migrated to another wallet.
- Based on recurring Mava tickets and support questions; aims to reduce confusion and prevent related issues.
