### PR TITLE
docs(vaults): clarify unwinding warning in withdrawal tutorial

### DIFF
--- a/fern/pages/vaults/tutorials/withdrawal.mdx
+++ b/fern/pages/vaults/tutorials/withdrawal.mdx
@@ -2,6 +2,12 @@
 title: Withdrawal
 ---
 
+<Warning>
+When withdrawing, your vault goes through an "unwinding" period where funds remain exposed to the market until positions are fully closed and converted to USDC. 
+
+This process usually takes a few minutes depending on market condition
+</Warning>
+
 <Steps>
   <Step title="Select a Vault">
     Select a Vault on the Vaults page that you wish to withdraw from.


### PR DESCRIPTION
This update adds a warning box to the Vault withdrawal tutorial clarifying the “unwinding” phase.

This change was suggested following a previous escalation to engineering and due to the frequency with which users ask about the unwinding status after a Vault withdrawal.

Eng thread: https://tradeparadigm.slack.com/archives/C02TUJZ6YEM/p1751922751599869