### PR TITLE
docs(wallets): add warning about permanent L1 wallet link

### DIFF
--- a/fern/pages/introduction/architecture-overview/wallet-integration.mdx
+++ b/fern/pages/introduction/architecture-overview/wallet-integration.mdx
@@ -73,7 +73,7 @@ See [MacOS documentation](https://support.apple.com/en-gb/guide/mac-help/mchlp29
 <Warning>
 The L1 wallet you connect during onboarding is permanently linked to your Paradex L2 account and cannot be updated later. 
 
-If you want to operate with a different L1 wallet, you’ll need to create a new Paradex account.
+If you want to operate with a different L1 wallet, you will need to create a new Paradex account.
 </Warning>
 
 ### References

--- a/fern/pages/introduction/architecture-overview/wallet-integration.mdx
+++ b/fern/pages/introduction/architecture-overview/wallet-integration.mdx
@@ -70,6 +70,12 @@ If “Remember Me” is checked when connecting the wallet, the Ethereum Signatu
 You should update the date and time on your device to be set automatically, to avoid issues when signing requests (e.g. during Onboarding/Authentication).\
 See [MacOS documentation](https://support.apple.com/en-gb/guide/mac-help/mchlp2996/mac) or [Windows documentation](https://support.microsoft.com/en-us/windows/how-to-set-your-time-and-time-zone-dfaa7122-479f-5b98-2a7b-fa0b6e01b261)
 
+<Warning>
+The L1 wallet you connect during onboarding is permanently linked to your Paradex L2 account and cannot be updated later. 
+
+If you want to operate with a different L1 wallet, you’ll need to create a new Paradex account.
+</Warning>
+
 ### References
 
 ***


### PR DESCRIPTION
This PR clarifies that the L1 wallet connected during onboarding is permanently linked to the Paradex L2 account.

Explains that users who want to change L1 wallet linked to an L2 must create a new Paradex account