### PR TITLE
[dex][docs] Add documentation for SNX-USD-PERP

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -553,7 +553,11 @@ navigation:
                     - page: ZRO-USD-PERP
                       slug: zro-usd-perp
                       path: ./pages/instruments-guide/futures/tier-2/zro-usd-perp.mdx
+
             - section: Options
+                    - page: SNX-USD-PERP
+                      slug: snx-usd-perp
+                      path: ./pages/instruments-guide/futures/tier-2/snx-usd-perp.mdx
               contents:
                 - page: BTC
                   slug: btc

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -460,6 +460,9 @@ navigation:
                     - page: SEI-USD-PERP
                       slug: sei-usd-perp
                       path: ./pages/instruments-guide/futures/tier-2/sei-usd-perp.mdx
+                    - page: SNX-USD-PERP
+                      slug: snx-usd-perp
+                      path: ./pages/instruments-guide/futures/tier-2/snx-usd-perp.mdx
                     - page: SOPH-USD-PERP
                       slug: soph-usd-perp
                       path: ./pages/instruments-guide/futures/tier-2/soph-usd-perp.mdx
@@ -553,11 +556,7 @@ navigation:
                     - page: ZRO-USD-PERP
                       slug: zro-usd-perp
                       path: ./pages/instruments-guide/futures/tier-2/zro-usd-perp.mdx
-
             - section: Options
-                    - page: SNX-USD-PERP
-                      slug: snx-usd-perp
-                      path: ./pages/instruments-guide/futures/tier-2/snx-usd-perp.mdx
               contents:
                 - page: BTC
                   slug: btc

--- a/fern/pages/instruments-guide/futures/tier-2/snx-usd-perp.mdx
+++ b/fern/pages/instruments-guide/futures/tier-2/snx-usd-perp.mdx
@@ -1,0 +1,21 @@
+---
+---
+export const contractName = "SNX-USD-PERP";
+export const productType = "SNX Perpetual Future";
+export const settlementCurrency = "USDC";
+export const baseCurrency = "SNX";
+export const quoteCurrency = "USD";
+export const fundingPeriod = "8.0 hours";
+export const tickSize = "0.00001 USD";
+export const orderSizeIncrement = "1 SNX";
+export const minOrderValue = "50 USD";
+export const maxOrderSize = "300,000 SNX";
+export const maxOpenOrders = "75";
+export const positionLimit = "1,000,000 SNX";
+export const priceBandFactor = "20.0%";
+export const fundingClampingRate = "5%";
+export const ewmaFactor = "20%";
+export const imf = "20%";
+export const mmf = "50%";
+
+<Markdown src="../../../../snippets/contractTemplate.mdx"/>


### PR DESCRIPTION
- Add new market page: snx-usd-perp.mdx
- Update docs.yml navigation
- Market details: SNX/USD perpetual future