### PR TITLE
[dex][docs] Add documentation for APEX-USD-PERP

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -553,7 +553,11 @@ navigation:
                     - page: ZRO-USD-PERP
                       slug: zro-usd-perp
                       path: ./pages/instruments-guide/futures/tier-2/zro-usd-perp.mdx
+
             - section: Options
+                    - page: APEX-USD-PERP
+                      slug: apex-usd-perp
+                      path: ./pages/instruments-guide/futures/tier-2/apex-usd-perp.mdx
               contents:
                 - page: BTC
                   slug: btc

--- a/fern/pages/instruments-guide/futures/tier-2/apex-usd-perp.mdx
+++ b/fern/pages/instruments-guide/futures/tier-2/apex-usd-perp.mdx
@@ -1,0 +1,21 @@
+---
+---
+export const contractName = "APEX-USD-PERP";
+export const productType = "APEX Perpetual Future";
+export const settlementCurrency = "USDC";
+export const baseCurrency = "APEX";
+export const quoteCurrency = "USD";
+export const fundingPeriod = "4.0 hours";
+export const tickSize = "0.0001 USD";
+export const orderSizeIncrement = "1 APEX";
+export const minOrderValue = "50 USD";
+export const maxOrderSize = "170,000 APEX";
+export const maxOpenOrders = "75";
+export const positionLimit = "550,000 APEX";
+export const priceBandFactor = "20.0%";
+export const fundingClampingRate = "2.5%";
+export const ewmaFactor = "20%";
+export const imf = "20%";
+export const mmf = "50%";
+
+<Markdown src="../../../../snippets/contractTemplate.mdx"/>


### PR DESCRIPTION
- Add new market page: apex-usd-perp.mdx
- Update docs.yml navigation
- Market details: APEX/USD perpetual future