### PR TITLE
[dex][docs] Add documentation for 2Z-USD-PERP

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -235,6 +235,9 @@ navigation:
                     - page: 0G-USD-PERP
                       slug: 0g-usd-perp
                       path: ./pages/instruments-guide/futures/tier-2/0g-usd-perp.mdx
+                    - page: 2Z-USD-PERP
+                      slug: 2z-usd-perp
+                      path: ./pages/instruments-guide/futures/tier-2/2z-usd-perp.mdx
                     - page: AAVE-USD-PERP
                       slug: aave-usd-perp
                       path: ./pages/instruments-guide/futures/tier-2/aave-usd-perp.mdx

--- a/fern/pages/instruments-guide/futures/tier-2/2z-usd-perp.mdx
+++ b/fern/pages/instruments-guide/futures/tier-2/2z-usd-perp.mdx
@@ -1,0 +1,21 @@
+---
+---
+export const contractName = "2Z-USD-PERP";
+export const productType = "2Z Perpetual Future";
+export const settlementCurrency = "USDC";
+export const baseCurrency = "2Z";
+export const quoteCurrency = "USD";
+export const fundingPeriod = "4.0 hours";
+export const tickSize = "0.00001 USD";
+export const orderSizeIncrement = "1 2Z";
+export const minOrderValue = "50 USD";
+export const maxOrderSize = "400,000 2Z";
+export const maxOpenOrders = "75";
+export const positionLimit = "1,300,000 2Z";
+export const priceBandFactor = "20.0%";
+export const fundingClampingRate = "2.5%";
+export const ewmaFactor = "20%";
+export const imf = "20%";
+export const mmf = "50%";
+
+<Markdown src="../../../../snippets/contractTemplate.mdx"/>


### PR DESCRIPTION
- Add new market page: 2z-usd-perp.mdx
- Update docs.yml navigation
- Market details: 2Z/USD perpetual future