### PR TITLE
[dex][docs] Add documentation for CAKE-USD-PERP

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -280,6 +280,9 @@ navigation:
                     - page: BNB-USD-PERP
                       slug: bnb-usd-perp
                       path: ./pages/instruments-guide/futures/tier-2/bnb-usd-perp.mdx
+                    - page: CAKE-USD-PERP
+                      slug: cake-usd-perp
+                      path: ./pages/instruments-guide/futures/tier-2/cake-usd-perp.mdx
                     - page: CRV-USD-PERP
                       slug: crv-usd-perp
                       path: ./pages/instruments-guide/futures/tier-2/crv-usd-perp.mdx

--- a/fern/pages/instruments-guide/futures/tier-2/cake-usd-perp.mdx
+++ b/fern/pages/instruments-guide/futures/tier-2/cake-usd-perp.mdx
@@ -1,0 +1,21 @@
+---
+---
+export const contractName = "CAKE-USD-PERP";
+export const productType = "CAKE Perpetual Future";
+export const settlementCurrency = "USDC";
+export const baseCurrency = "CAKE";
+export const quoteCurrency = "USD";
+export const fundingPeriod = "4.0 hours";
+export const tickSize = "0.0001 USD";
+export const orderSizeIncrement = "1 CAKE";
+export const minOrderValue = "50 USD";
+export const maxOrderSize = "90,000 CAKE";
+export const maxOpenOrders = "75";
+export const positionLimit = "290,000 CAKE";
+export const priceBandFactor = "20.0%";
+export const fundingClampingRate = "2.5%";
+export const ewmaFactor = "20%";
+export const imf = "20%";
+export const mmf = "50%";
+
+<Markdown src="../../../../snippets/contractTemplate.mdx"/>


### PR DESCRIPTION
- Add new market page: cake-usd-perp.mdx
- Update docs.yml navigation
- Market details: CAKE/USD perpetual future