### PR TITLE
[dex][docs] Sync both specs (prod) from mono@release/paradex-1.142.11

### DIFF
--- a/fern/apis/prod_rest/openapi/openapi.json
+++ b/fern/apis/prod_rest/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "The following describe Paradex API.\n",
     "title": "Paradex REST API",
     "contact": {},
-    "version": "1.120.0"
+    "version": "1.120.1"
   },
   "paths": {
     "/account": {
@@ -980,6 +980,43 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/responses.ApiError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/responses.ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/account/profile/notifications/last_seen": {
+      "post": {
+        "security": [
+          {
+            "BearerToken": []
+          }
+        ],
+        "description": "Records current server time as the notification dedup watermark for cross-device dedup.",
+        "tags": [
+          "Account"
+        ],
+        "summary": "Updates the last-seen notification timestamp",
+        "operationId": "update-last-seen",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/responses.AccountProfileResp"
                 }
               }
             }
@@ -7507,6 +7544,10 @@
             "type": "boolean",
             "example": true
           },
+          "last_seen_notification": {
+            "type": "integer",
+            "example": 1713400000000
+          },
           "market_max_slippage": {
             "type": "object",
             "additionalProperties": {
@@ -7597,6 +7638,11 @@
             "description": "Amount required to open trade for the existing positions",
             "type": "string",
             "example": "63008.59689218"
+          },
+          "last_seen_notification": {
+            "description": "Latest notification event timestamp (ms) the user has seen — used for cross-device dedup",
+            "type": "integer",
+            "example": 1713400000000
           },
           "maintenance_margin_requirement": {
             "description": "Amount required to maintain exisiting positions",

--- a/fern/apis/prod_ws/asyncapi-2.6.0.yaml
+++ b/fern/apis/prod_ws/asyncapi-2.6.0.yaml
@@ -1,7 +1,7 @@
 asyncapi: 2.6.0
 info:
     title: WebSocket channels
-    version: 1.1.0
+    version: 1.2.0
     description: Channels for real-time updates.
 servers:
     production:
@@ -75,7 +75,7 @@ channels:
                 payload:
                     $ref: '#/components/schemas/ResponsesBBOResp'
                 summary: Public websocket channel for tick updates of orderbook best bid/ask prices and amounts
-                description: Subscribe to market messages
+                description: 'Subscribe to market messages. Use `bbo.{market_symbol}` for a single market, `bbo.ALL` for every market, or pass `{"channel": "bbo", "base_asset": "{base_asset}"}` to receive updates for every active options market (OPTION and PERP_OPTION) for the given base asset.'
         x-fern-display-name: bbo.{market_symbol}
     /fills.{market_symbol}:
         parameters:
@@ -1016,7 +1016,7 @@ channels:
                 payload:
                     $ref: '#/components/schemas/ResponsesTradeResult'
                 summary: Public websocket channel to receive updates on trades in particular market
-                description: Subscribe to trade messages for a market
+                description: 'Subscribe to trade messages. Use `trades.{market_symbol}` for a single market, `trades.ALL` for every market, or pass `{"channel": "trades", "base_asset": "{base_asset}"}` to receive updates for every active options market (OPTION and PERP_OPTION) for the given base asset.'
         x-fern-display-name: trades.{market_symbol}
     /transaction:
         subscribe:
@@ -1139,6 +1139,10 @@ components:
                     description: Amount required to open trade for the existing positions
                     example: "63008.59689218"
                     type: string
+                last_seen_notification:
+                    description: Latest notification event timestamp (ms) the user has seen — used for cross-device dedup
+                    example: "1713400000000"
+                    type: integer
                 maintenance_margin_requirement:
                     description: Amount required to maintain exisiting positions
                     example: "31597.25239676"
@@ -1179,6 +1183,7 @@ components:
                 - updated_at
                 - status
                 - seq_no
+                - last_seen_notification
             type: object
         ResponsesBBOResp:
             additionalProperties: false
@@ -2310,7 +2315,7 @@ components:
             name: bboresp
             title: BBOResp
             summary: Public websocket channel for tick updates of orderbook best bid/ask prices and amounts
-            description: Subscribe to market messages
+            description: 'Subscribe to market messages. Use `bbo.{market_symbol}` for a single market, `bbo.ALL` for every market, or pass `{"channel": "bbo", "base_asset": "{base_asset}"}` to receive updates for every active options market (OPTION and PERP_OPTION) for the given base asset.'
             tags:
                 - name: market
         ResponsesBalanceEventResponse:
@@ -2374,7 +2379,7 @@ components:
             name: traderesult
             title: TradeResult
             summary: Public websocket channel to receive updates on trades in particular market
-            description: Subscribe to trade messages for a market
+            description: 'Subscribe to trade messages. Use `trades.{market_symbol}` for a single market, `trades.ALL` for every market, or pass `{"channel": "trades", "base_asset": "{base_asset}"}` to receive updates for every active options market (OPTION and PERP_OPTION) for the given base asset.'
             tags:
                 - name: market
         ResponsesTradebustResult:

--- a/fern/apis/prod_ws/openrpc.json
+++ b/fern/apis/prod_ws/openrpc.json
@@ -2,7 +2,7 @@
   "openrpc": "1.3.2",
   "info": {
     "title": "Paradex WebSocket RPC API",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "JSON-RPC 2.0 methods for the Paradex WebSocket API. All requests follow the envelope: {\"jsonrpc\":\"2.0\",\"method\":\"\u003cname\u003e\",\"params\":{...},\"id\":\u003cint\u003e}. Responses include usIn/usOut/usDiff nanosecond timing fields."
   },
   "servers": [


### PR DESCRIPTION
Automated sync of both specs (prod) from [mono@release/paradex-1.142.11](https://github.com/tradeparadigm/mono/commit/cce226c27b2e44bee489c69bbfc5ac1ee0dd64a6).