### PR TITLE
[dex][docs] Sync both specs (prod) from mono@release/paradex-1.143.0

### DIFF
--- a/fern/apis/prod_rest/openapi/openapi.json
+++ b/fern/apis/prod_rest/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "The following describe Paradex API.\n",
     "title": "Paradex REST API",
     "contact": {},
-    "version": "1.120.1"
+    "version": "1.120.2"
   },
   "paths": {
     "/account": {
@@ -5061,6 +5061,15 @@
         "operationId": "trades",
         "parameters": [
           {
+            "example": "BTC",
+            "description": "Base asset symbol; returns trades across all active options (OPTION and PERP_OPTION) for this base asset. Mutually exclusive with market.",
+            "name": "baseAsset",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "description": "Returns the ‘next’ paginated page.",
             "name": "cursor",
             "in": "query",
@@ -5078,10 +5087,9 @@
           },
           {
             "example": "BTC-USD-PERP",
-            "description": "Market name",
+            "description": "Market name. Mutually exclusive with base_asset.",
             "name": "market",
             "in": "query",
-            "required": true,
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
Automated sync of both specs (prod) from [mono@release/paradex-1.143.0](https://github.com/tradeparadigm/mono/commit/3dff05897adb0c13e7ad7314cd34b2243b53d8dd).