### PR TITLE
[dex][docs] Sync both specs (prod) from mono@release/paradex-1.144.4

### DIFF
--- a/fern/apis/prod_rest/openapi/openapi.json
+++ b/fern/apis/prod_rest/openapi/openapi.json
@@ -9733,6 +9733,11 @@
             "type": "string",
             "example": "29876.3"
           },
+          "forward_rate": {
+            "description": "EWMA-smoothed annualized forward rate for dated options",
+            "type": "string",
+            "example": "0.05"
+          },
           "funding_rate": {
             "description": "This raw funding rate corresponds to the actual funding period of the instrument itself. It is not a normalized 8h funding rate.",
             "type": "string",

--- a/fern/apis/prod_ws/asyncapi-2.6.0.yaml
+++ b/fern/apis/prod_ws/asyncapi-2.6.0.yaml
@@ -1522,6 +1522,10 @@ components:
                     description: 'External fair price, calculated from spot price and an external basis: spot_price * (1 + external_basis). where external basis is the median basis rate on different external exchanges'
                     example: "29876.3"
                     type: string
+                forward_rate:
+                    description: EWMA-smoothed annualized forward rate for dated options
+                    example: "0.05"
+                    type: string
                 funding_rate:
                     description: This raw funding rate corresponds to the actual funding period of the instrument itself. It is not a normalized 8h funding rate.
                     example: "0.3"


### PR DESCRIPTION
Automated sync of both specs (prod) from [mono@release/paradex-1.144.4](https://github.com/tradeparadigm/mono/commit/e000d89a418d96b938faed9ba7f8636611106c53).