### PR TITLE
[dex][docs] Sync both specs (prod) from mono@release/paradex-1.145.0

### DIFF
--- a/fern/apis/prod_rest/openapi/openapi.json
+++ b/fern/apis/prod_rest/openapi/openapi.json
@@ -9795,6 +9795,11 @@
             "type": "string",
             "example": "0.05"
           },
+          "risk_free_rate": {
+            "description": "Risk-free discounting rate used for option pricing",
+            "type": "string",
+            "example": "0.05"
+          },
           "rolling_details": {
             "description": "Rolling futures details — only populated for rolling futures markets",
             "allOf": [

--- a/fern/apis/prod_ws/asyncapi-2.6.0.yaml
+++ b/fern/apis/prod_ws/asyncapi-2.6.0.yaml
@@ -1,7 +1,7 @@
 asyncapi: 2.6.0
 info:
     title: WebSocket channels
-    version: 1.2.0
+    version: 1.2.1
     description: Channels for real-time updates.
 servers:
     production:
@@ -1593,6 +1593,10 @@ components:
                     type: string
                 price_change_rate_24h:
                     description: Price change rate in the last 24 hours
+                    example: "0.05"
+                    type: string
+                risk_free_rate:
+                    description: Risk-free discounting rate used for option pricing
                     example: "0.05"
                     type: string
                 rolling_details:

--- a/fern/apis/prod_ws/openrpc.json
+++ b/fern/apis/prod_ws/openrpc.json
@@ -2,7 +2,7 @@
   "openrpc": "1.3.2",
   "info": {
     "title": "Paradex WebSocket RPC API",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "JSON-RPC 2.0 methods for the Paradex WebSocket API. All requests follow the envelope: {\"jsonrpc\":\"2.0\",\"method\":\"\u003cname\u003e\",\"params\":{...},\"id\":\u003cint\u003e}. Responses include usIn/usOut/usDiff nanosecond timing fields."
   },
   "servers": [


### PR DESCRIPTION
Automated sync of both specs (prod) from [mono@release/paradex-1.145.0](https://github.com/tradeparadigm/mono/commit/d8d5be49f6c7e7107e75b579169e4b7b2057396b).