### PR TITLE
[dex][docs] Sync both specs (prod) from mono@release/paradex-1.149.2

### DIFF
--- a/fern/apis/prod_rest/openapi/openapi.json
+++ b/fern/apis/prod_rest/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "The following describe Paradex API.\n",
     "title": "Paradex REST API",
     "contact": {},
-    "version": "1.124.0"
+    "version": "1.124.1"
   },
   "paths": {
     "/account": {
@@ -9148,9 +9148,6 @@
           "PROFILE_STATS_NOT_FOUND",
           "INVALID_CHAIN",
           "INVALID_LAYERSWAP_SWAP",
-          "INVALID_RHINOFI_REQUEST",
-          "INVALID_RHINOFI_QUOTE",
-          "INVALID_RHINOFI_QUOTE_COMMIT",
           "SOCIAL_USERNAME_IN_USE",
           "INVALID_OAUTH_REQUEST",
           "RPI_ACCOUNT_NOT_WHITELISTED",
@@ -9262,9 +9259,6 @@
           "ErrorCodeString_ProfileStatsNotFound",
           "ErrorCodeString_InvalidChain",
           "ErrorCodeString_InvalidLayerswapSwap",
-          "ErrorCodeString_InvalidRhinofiRequest",
-          "ErrorCodeString_InvalidRhinofiQuote",
-          "ErrorCodeString_InvalidRhinofiQuoteCommit",
           "ErrorCodeString_SocialUsernameInUse",
           "ErrorCodeString_InvalidOAuthRequest",
           "ErrorCodeString_RPIAccountNotWhitelisted",


### PR DESCRIPTION
Automated sync of both specs (prod) from [mono@release/paradex-1.149.2](https://github.com/tradeparadigm/mono/commit/afbf164d0a5ff1f9d1475574fe33aed17feaf267).