### PR TITLE
[dex][docs] Sync both specs (prod) from mono@release/paradex-1.149.7

### DIFF
--- a/fern/apis/prod_rest/openapi/openapi.json
+++ b/fern/apis/prod_rest/openapi/openapi.json
@@ -6177,11 +6177,11 @@
             "BearerToken": []
           }
         ],
-        "description": "Returns all vaults (any status) where the caller is the operator or owner.\nIt includes vaults not active yet, like initializing or pending initial deposit.",
+        "description": "Returns all vaults (any status) where the caller is the operator or owner,\nplus the vault the caller is a sub-operator (strategy) of, if any.\nIt includes vaults not active yet, like initializing or pending initial deposit.\nEach vault includes its strategies (sub-operators), so the UI can resolve\nvalid operator <-> sub-operator transfer counterparties.",
         "tags": [
           "Vaults"
         ],
-        "summary": "Get vaults owned or operated by the authenticated account",
+        "summary": "Get vaults owned, operated, or sub-operated by the authenticated account",
         "operationId": "vaults-get-mine",
         "responses": {
           "200": {


### PR DESCRIPTION
Automated sync of both specs (prod) from [mono@release/paradex-1.149.7](https://github.com/tradeparadigm/mono/commit/b2ae67342c03cb1bfb92c85142407190ba5412c8).