### PR TITLE
[dex][docs] Sync both specs (prod) from mono@fff951d

### DIFF
--- a/fern/apis/prod_rest/openapi/openapi.json
+++ b/fern/apis/prod_rest/openapi/openapi.json
@@ -5186,7 +5186,7 @@
     },
     "/system/time": {
       "get": {
-        "description": "Get the current time in the Paradex\n",
+        "description": "Get the current time in the Paradex system, in unix milliseconds.\n\n(sync-docs token validation test — revert before merging)\n",
         "tags": [
           "System"
         ],


### PR DESCRIPTION
Automated sync of both specs (prod) from [mono@fff951d](https://github.com/tradeparadigm/mono/commit/fff951df13a5049de4ad55206ffdf8480af69c13).