### PR TITLE
[dex][docs] Sync both specs (prod) from mono@release/paradex-1.155.3

### DIFF
--- a/fern/apis/prod_rest/openapi/openapi.json
+++ b/fern/apis/prod_rest/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "The following describe Paradex API.\n",
     "title": "Paradex REST API",
     "contact": {},
-    "version": "1.127.1"
+    "version": "1.128.0"
   },
   "paths": {
     "/account": {
@@ -9546,7 +9546,7 @@
             "example": "USDC"
           },
           "fill_type": {
-            "description": "Fill type, can be FILL, LIQUIDATION or TRANSFER",
+            "description": "Fill type, can be FILL, LIQUIDATION or UNWIND_TRANSFER",
             "allOf": [
               {
                 "$ref": "#/components/schemas/responses.FillType"
@@ -9637,7 +9637,7 @@
         "type": "string",
         "enum": [
           "LIQUIDATION",
-          "TRANSFER",
+          "UNWIND_TRANSFER",
           "FILL",
           "SETTLE_MARKET",
           "RPI",
@@ -9645,7 +9645,7 @@
         ],
         "x-enum-varnames": [
           "FillTypeLiquidation",
-          "FillTypeTransfer",
+          "FillTypeUnwindTransfer",
           "FillTypeFill",
           "FillTypeSettleMarket",
           "FillTypeRPI",

--- a/fern/apis/prod_ws/asyncapi-2.6.0.yaml
+++ b/fern/apis/prod_ws/asyncapi-2.6.0.yaml
@@ -1416,10 +1416,10 @@ components:
                     example: USDC
                     type: string
                 fill_type:
-                    description: Fill type, can be FILL, LIQUIDATION or TRANSFER
+                    description: Fill type, can be FILL, LIQUIDATION or UNWIND_TRANSFER
                     enum:
                         - LIQUIDATION
-                        - TRANSFER
+                        - UNWIND_TRANSFER
                         - FILL
                         - SETTLE_MARKET
                         - RPI
@@ -2435,7 +2435,7 @@ components:
                     description: Trade type, can be FILL, LIQUIDATION, or RPI
                     enum:
                         - LIQUIDATION
-                        - TRANSFER
+                        - UNWIND_TRANSFER
                         - FILL
                         - SETTLE_MARKET
                         - RPI


### PR DESCRIPTION
Automated sync of both specs (prod) from [mono@release/paradex-1.155.3](https://github.com/tradeparadigm/mono/commit/9c729a923531b38f6f7715e049ee97a3f2f9f8aa).