### PR TITLE
docs(ecosystem): add third-party benchmarks card to Integrations

### DIFF
--- a/fern/pages/ecosystem/overview.mdx
+++ b/fern/pages/ecosystem/overview.mdx
@@ -31,6 +31,10 @@ The Paradex ecosystem is a growing network of integrations, tools, and community
   <Card title="Community Content" icon="fa-solid fa-users" href="/ecosystem/community-content">
     A curated showcase of tools, bots, and resources built by Paradex users including trading automation, analytics, and developer libraries.
   </Card>
+
+  <Card title="Third-Party Benchmarks" icon="fa-solid fa-chart-bar" href="https://openchainbench.com/benchmarks/perp-fees">
+    OpenChainBench publishes independent measurements of Paradex fees, funding stability, and API latency versus other perpetual venues, under a CC BY 4.0 license.
+  </Card>
 </CardGroup>
 
 ## Featured Community Projects


### PR DESCRIPTION
Adds a new `<Card>` to the Integrations CardGroup in `fern/pages/ecosystem/overview.mdx`, alongside the existing Price Oracles and Community Content cards.

**Why this fits:**
- The Ecosystem page already lists third-party services and integrations (Pyth/Stork oracles, community tools, bridges)
- OpenChainBench provides independent measurements of Paradex fees, funding stability, and API latency versus other perpetual venues
- Paradex currently ranks well across these benches (#3 perp-fees, #4 perp-funding-stability)

**What's added:**
- One new `<Card>` element inside the existing `<CardGroup cols={2}>` under Integrations
- Single external link to https://openchainbench.com/benchmarks/perp-fees
- Format matches the existing cards in the section

**About OpenChainBench:** independent open-source project benchmarking perpetual venues and blockchain infrastructure, published under CC BY 4.0. No affiliation with Paradex or any competing venue.

**Disclosure:** I contribute to OpenChainBench. Happy to reword or drop entirely if this doesn't fit editorial guidelines.