### PR TITLE
[dex][docs] Sync both specs (prod) from mono@release/paradex-1.156.0

### DIFF
--- a/fern/apis/prod_rest/openapi/openapi.json
+++ b/fern/apis/prod_rest/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "The following describe Paradex API.\n",
     "title": "Paradex REST API",
     "contact": {},
-    "version": "1.128.1"
+    "version": "1.128.2"
   },
   "paths": {
     "/account": {
@@ -7466,8 +7466,9 @@
         ],
         "properties": {
           "amount": {
-            "description": "Amount of XP to transfer (must be >= 1)",
+            "description": "Amount of XP to transfer (must be >= 1 and <= 1e12)",
             "type": "integer",
+            "maximum": 1000000000000,
             "minimum": 1,
             "example": 100
           },


### PR DESCRIPTION
Automated sync of both specs (prod) from [mono@release/paradex-1.156.0](https://github.com/tradeparadigm/mono/commit/f29d4bc46a94e676842410859424a11c6453f8ea).