### PR TITLE
[dex][docs] Sync both specs (prod) from mono@release/paradex-1.158.1

### DIFF
--- a/fern/apis/prod_ws/asyncapi-2.6.0.yaml
+++ b/fern/apis/prod_ws/asyncapi-2.6.0.yaml
@@ -1,7 +1,7 @@
 asyncapi: 2.6.0
 info:
     title: WebSocket channels
-    version: 1.2.1
+    version: 1.2.2
     description: Channels for real-time updates.
 servers:
     production:
@@ -2346,6 +2346,9 @@ components:
                             type: string
                         order_id:
                             description: Venue-issued order id, RFQ_EXECUTE OK only
+                            type: string
+                        request_id:
+                            description: Paradex-issued id returned by the REST 202 and echoed here for correlation
                             type: string
                         status:
                             type: string

--- a/fern/apis/prod_ws/openrpc.json
+++ b/fern/apis/prod_ws/openrpc.json
@@ -2,7 +2,7 @@
   "openrpc": "1.3.2",
   "info": {
     "title": "Paradex WebSocket RPC API",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "JSON-RPC 2.0 methods for the Paradex WebSocket API. All requests follow the envelope: {\"jsonrpc\":\"2.0\",\"method\":\"\u003cname\u003e\",\"params\":{...},\"id\":\u003cint\u003e}. Responses include usIn/usOut/usDiff nanosecond timing fields."
   },
   "servers": [


### PR DESCRIPTION
Automated sync of both specs (prod) from [mono@release/paradex-1.158.1](https://github.com/tradeparadigm/mono/commit/c8c667606682d605db73159cfbd39da47d86f67a).